### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/shabda/cache.py
+++ b/shabda/cache.py
@@ -14,7 +14,10 @@ os.makedirs(CACHE_PATH, exist_ok=True)
 def save(key, value, ttl=60 * 60 * 24):
     """Write a key:value pair to cache."""
     # ttl is "time to live" of the item in seconds
-    filepath = CACHE_PATH + key
+    filepath = os.path.normpath(os.path.join(CACHE_PATH, key))
+    # Ensure the normalized filepath is within CACHE_PATH
+    if not filepath.startswith(os.path.normpath(CACHE_PATH)):
+        raise Exception("Invalid cache key: path traversal detected")
     expiry = int(time.time() + ttl)
     cache = (expiry, value)
     with open(filepath, "w+b") as file:
@@ -23,7 +26,10 @@ def save(key, value, ttl=60 * 60 * 24):
 
 def load(key):
     """Read the value for given key from cache."""
-    filepath = CACHE_PATH + key
+    filepath = os.path.normpath(os.path.join(CACHE_PATH, key))
+    # Ensure the normalized filepath is within CACHE_PATH
+    if not filepath.startswith(os.path.normpath(CACHE_PATH)):
+        raise Exception("Invalid cache key: path traversal detected")
     try:
         with open(filepath, "r+b") as file:
             expiry, value = pickle.load(file)


### PR DESCRIPTION
Potential fix for [https://github.com/ilesinge/shabda/security/code-scanning/3](https://github.com/ilesinge/shabda/security/code-scanning/3)

The `save` and `load` methods in `shabda/cache.py` should ensure that any constructed cache file path is strictly contained within the intended cache directory (`CACHE_PATH`). We can achieve this by:

1. **Normalizing the path:** Use `os.path.normpath` on the constructed cache file path after joining the base cache path and the key.
2. **Checking if the resulting path is within the intended cache directory:** After normalizing, check that the resulting path starts with the cache directory (`CACHE_PATH`), using `os.path.commonpath` or a prefix check (with careful handling to avoid substring tricks).
3. **Optional extra:** If cache keys should always match a certain pattern (such as alphanumeric plus underscores), you could restrict keys to those allowed characters. However, since the cache key format may legitimately include other formats, the safest and most generic fix is confinement to the cache dir as above.

The edit is needed in shabda/cache.py, within the `save` and `load` methods, on where `filepath` is constructed.  
We need to:
- Replace simple concatenation with `os.path.join`.
- Apply normalization with `os.path.normpath`.
- Check with `os.path.commonpath` or prefix check that the result is inside `CACHE_PATH`.
- Raise an exception if not allowed, to prevent writing/reading unauthorized files.
- Import any required method(s) if not already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
