### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/shabda/web.py
+++ b/shabda/web.py
@@ -17,6 +17,7 @@ from flask import (
     after_this_request,
 )
 from werkzeug.exceptions import BadRequest, HTTPException
+from werkzeug.utils import secure_filename
 from shabda.dj import Dj
 
 
@@ -146,11 +147,12 @@ def pack_zip(definition):
 def speech_zip(definition):
     """Download a zip archive"""
     definition = definition.replace(" ", "_")
+    definition_secure = secure_filename(definition)
     try:
         words = dj.parse_definition(definition)
     except ValueError as ex:
         raise BadRequest(ex) from ex
-    tmpfile = tempfile.gettempdir() + "/" + definition + ".zip"
+    tmpfile = os.path.join(tempfile.gettempdir(), definition_secure + ".zip")
     with ZipFile(tmpfile, "w") as zipfile:
         for word, number in words.items():
             samples = dj.list(word, number, soundtype="tts")


### PR DESCRIPTION
Potential fix for [https://github.com/ilesinge/shabda/security/code-scanning/1](https://github.com/ilesinge/shabda/security/code-scanning/1)

The best way to fix this problem is to sanitize the user-provided `definition` string before using it in path construction. In this scenario, the definition is only used for naming a temporary file; therefore, the safest method is to pass it through `werkzeug.utils.secure_filename` before concatenating it into the file path. This eliminates dangerous characters and prevents directory traversal. 

You should import `secure_filename` from `werkzeug.utils` at the top of the file, and then, just before constructing `tmpfile`, apply it:  
`definition_secure = secure_filename(definition)`  
Use `definition_secure` when forming `tmpfile`.

**Files/regions/lines to change:**  
- In `shabda/web.py`, add `from werkzeug.utils import secure_filename`.
- In the `speech_zip` function, convert `definition` using `secure_filename` before using it to build `tmpfile`.
- Use the secured variable everywhere a path component is needed for this filename.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
